### PR TITLE
Playing audio directly from terminal

### DIFF
--- a/Stephanie/TextManager/speaker.py
+++ b/Stephanie/TextManager/speaker.py
@@ -17,7 +17,7 @@ class Speaker:
             if platform.system() == "Linux":
                 os.system("xdg-open " + self.speak_result)
             elif platform.system() == "Darwin":
-                os.system("open " + self.speak_result)
+                os.system("afplay " + self.speak_result)
             elif platform.system() == "Windows":
                 os.startfile(self.speak_result)
             else:


### PR DESCRIPTION
The `open` command on Mac OSX would always open a new audio file in the audio player that I was running. `afplay` instead just plays an audio clip directly from the audio output. Makes it a lot less frustrating when testing out the various modules.

Since I only use Mac, not sure how this functionality across other OS. Perhaps the `sox` command would work for Linux? https://linux.die.net/man/1/play